### PR TITLE
ci: automatically build & push docker image to ghcr.io

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,97 @@
+name: Docker build & push to ghcr.io
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  push:
+    branches: ["main"]
+    # Publish semver tags as releases.
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: ["main"]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.4 AS Build
+FROM golang AS Build
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
@@ -7,12 +7,13 @@ COPY cmd ./cmd
 COPY pkg ./pkg
 RUN CGO_ENABLED=0 GOOS=linux go build -o /gpodder2go
 
-FROM alpine:3.18.4
+FROM alpine
 RUN mkdir /data
 WORKDIR /data
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /data
+RUN chmod +x /data /entrypoint.sh
 COPY --from=Build /gpodder2go /gpodder2go
+
 EXPOSE 3005
 VOLUME /data
-CMD ["/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -88,6 +88,36 @@ Add with:
 
 ### Docker
 
+```sh
+$ docker run -d \
+--name gpodder2go \
+-p 3005:3005 \
+-v <data_directory>:/data \
+oxtyped/gpodder2go:latest
+```
+
+With docker compose:
+
+```yaml
+version: '3'
+services:
+  gpodder2go:
+    image: oxtyped/gpodder2go:latest
+    ports:
+      - 3005:3005
+    volumes:
+      - ./gpodder2go:/data
+    restart: unless-stopped
+```
+
+To configure the server run
+
+```sh
+$ docker exec --it gpodder2go /gpodder2go ...
+```
+
+#### Build docker image from source
+
 Build with:
 
 ```


### PR DESCRIPTION
As @TheBluesky mentioned in #17 it would be nice to have automatic docker builds.
GitHub Actions provides this for free.

This action builds and pushes the image to ghcr.io, directly linked to the github repository.

The resulting image will be `ghcr.io/oxtyped/gpodder2go`.

Releases are labeled with :latest and :main is the main branch (latest commit)

Have a look at https://github.com/tippfehlr/gpodder2go in the sidebar, the ci ran in my fork and built an image