### PR TITLE
ensures the entrypoint exits non-zero when an error happens

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+set -e
+
 if [ ! -f "/data/g2g.db" ]; then
     echo "No database found, intializing gpodder2go ..."
     /gpodder2go init


### PR DESCRIPTION
fixes #40

output with the change:

```
[mhrivnak@roadie ]$ podman run --rm -it -v /:/data localhost/gp2g
No database found, intializing gpodder2go ...
2024/12/12 14:51:12 unable to open database file: out of memory (14)
[mhrivnak@roadie ]$ echo $?
1
```