### PR TITLE
uses exec to start serving from entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ if [ ! -f "/data/VERIFIER_SECRET_KEY" ]; then
     echo "... VERIFIER_SECRET_KEY initialized"
 fi
 if [ "$NO_AUTH" == true ]; then
-    VERIFIER_SECRET_KEY="$(cat /data/VERIFIER_SECRET_KEY)" /gpodder2go serve --addr "${ADDR:-0.0.0.0:3005}" --no-auth
+    VERIFIER_SECRET_KEY="$(cat /data/VERIFIER_SECRET_KEY)" exec /gpodder2go serve --addr "${ADDR:-0.0.0.0:3005}" --no-auth
 else
-    VERIFIER_SECRET_KEY="$(cat /data/VERIFIER_SECRET_KEY)" /gpodder2go serve --addr "${ADDR:-0.0.0.0:3005}"
+    VERIFIER_SECRET_KEY="$(cat /data/VERIFIER_SECRET_KEY)" exec /gpodder2go serve --addr "${ADDR:-0.0.0.0:3005}"
 fi


### PR DESCRIPTION
Previously, the entrypoint script left a shell process running forever, consuming some modest resources. This change uses `exec` to ensure that the gpodder2go process replaces the shell process, which is a best practice for containerization.

You can see a `sh` process running alongside `gpodder2go`:

```
[mhrivnak@roadie ]$ podman ps
CONTAINER ID  IMAGE                            COMMAND     CREATED         STATUS         PORTS       NAMES
9ca019f13341  ghcr.io/oxtyped/gpodder2go:main              18 seconds ago  Up 18 seconds  3005/tcp    gpodder2go
[mhrivnak@roadie ]$ podman exec -it gpodder2go ps -Af
PID   USER     TIME  COMMAND
    1 root      0:00 {entrypoint.sh} /bin/sh /entrypoint.sh
   13 root      0:00 /gpodder2go serve --addr 0.0.0.0:3005
   19 root      0:00 ps -Af
```

after this change, the shell process is gone:

```
[mhrivnak@roadie ]$ podman ps
CONTAINER ID  IMAGE                  COMMAND     CREATED         STATUS         PORTS       NAMES
1c33ba12b5a5  localhost/gp2g:latest              10 seconds ago  Up 11 seconds  3005/tcp    gpodder2go
[mhrivnak@roadie gpodder2go-container]$ podman exec -it gpodder2go ps -Af
PID   USER     TIME  COMMAND
    1 root      0:00 /gpodder2go serve --addr 0.0.0.0:3005
   18 root      0:00 ps -Af
   ```